### PR TITLE
Properly apply templates to alignments in alignment generator

### DIFF
--- a/DnDGen.CreatureGen.Tests.Integration.Stress/StressTests.cs
+++ b/DnDGen.CreatureGen.Tests.Integration.Stress/StressTests.cs
@@ -21,9 +21,9 @@ namespace DnDGen.CreatureGen.Tests.Integration.Stress
             var options = new StressorOptions();
             options.RunningAssembly = Assembly.GetExecutingAssembly();
 
-            //INFO: Non-stress operations take up to 10 minutes, or ~17% of the total runtime.
-            //Adding in another 3% of buffer
-            options.TimeLimitPercentage = .80;
+            //INFO: Non-stress operations take up to 15 minutes, or 25% of the total runtime.
+            //Adding in another 5% of buffer
+            options.TimeLimitPercentage = .70;
 
             //INFO: When the tests run in parallel, and with parallel batches, the overhead of multithread switching severely impacts execution time
             //Better to let it only one 1 at a time.

--- a/DnDGen.CreatureGen.Tests.Integration/Generators/CreatureGeneratorTests.cs
+++ b/DnDGen.CreatureGen.Tests.Integration/Generators/CreatureGeneratorTests.cs
@@ -8,6 +8,7 @@ using DnDGen.CreatureGen.Tests.Integration.TestData;
 using DnDGen.TreasureGen.Items;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -817,16 +818,34 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
             GenerateAndAssertRandomCreature(asCharacter, type, challengeRating, alignment, randomizer, template);
         }
 
+        [Test]
+        [Repeat(100)]
+        public void BUG_GenerateCreatureWithProblematicFilters_HalfDragonCelestial()
+        {
+            var templates = new[] { CreatureConstants.Templates.HalfDragon_Gold, CreatureConstants.Templates.CelestialCreature };
+            var randomizer = abilityRandomizerFactory.GetAbilityRandomizer(templates);
+            GenerateAndAssertRandomCreature(false, null, null, null, randomizer, templates);
+        }
+
+        [Test]
+        [Repeat(100)]
+        public void BUG_GenerateCreatureWithProblematicFilters_DriderHalfDragonCelestial()
+        {
+            var templates = new[] { CreatureConstants.Templates.HalfDragon_Gold, CreatureConstants.Templates.CelestialCreature };
+            var creature = creatureGenerator.Generate(false, CreatureConstants.Drider, null, templates);
+            creatureAsserter.AssertCreature(creature);
+        }
+
         private Creature GenerateAndAssertRandomCreature(
             bool asCharacter,
             string type,
             string challengeRating,
             string alignment,
             AbilityRandomizer randomizer,
-            string template)
+            params string[] templates)
         {
             var filters = new Filters();
-            filters.Templates.Add(template);
+            filters.Templates.AddRange(templates);
             filters.Type = type;
             filters.ChallengeRating = challengeRating;
             filters.Alignment = alignment;
@@ -836,7 +855,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
             stopwatch.Stop();
 
             var message = new StringBuilder();
-            var messageTemplate = !string.IsNullOrEmpty(template) ? template : "(None)";
+            var messageTemplate = filters.CleanTemplates.Count > 0 ? string.Join(", ", filters.CleanTemplates) : "(None)";
 
             message.AppendLine($"Creature: {creature.Summary}");
             message.AppendLine($"As Character: {asCharacter}");
@@ -848,10 +867,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
             var timeLimit = creatureAsserter.GetGenerationTimeLimitInSeconds(creature);
             Assert.That(stopwatch.Elapsed.TotalSeconds, Is.LessThan(timeLimit), message.ToString());
 
-            if (!string.IsNullOrEmpty(template) && template != CreatureConstants.Templates.None)
-                Assert.That(creature.Templates, Is.EqualTo([template]), message.ToString());
-            else if (template == CreatureConstants.Templates.None)
-                Assert.That(creature.Templates, Is.Empty, message.ToString());
+            Assert.That(creature.Templates, Is.EqualTo(filters.CleanTemplates), message.ToString());
 
             if (type != null)
                 creatureAsserter.AssertCreatureIsType(creature, type, message.ToString());

--- a/DnDGen.CreatureGen.Tests.Integration/Generators/CreatureGeneratorTests.cs
+++ b/DnDGen.CreatureGen.Tests.Integration/Generators/CreatureGeneratorTests.cs
@@ -72,7 +72,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         [TestCase(CreatureConstants.Nymph)]
         [TestCase(CreatureConstants.Rakshasa)]
         [TestCase(CreatureConstants.TrumpetArchon)]
-        public void CanGenerateSpellsForThoseWhoCastAsSpellcaster(string creatureName)
+        public void Generate_SpellsForThoseWhoCastAsSpellcaster(string creatureName)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             creatureAsserter.AssertCreature(creature);
@@ -95,7 +95,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         [TestCase(CreatureConstants.Balor)]
         [TestCase(CreatureConstants.Titan)]
         [TestCase(CreatureConstants.Giant_Cloud)]
-        public void CanGenerateWeapons(string creatureName)
+        public void Generate_Weapons(string creatureName)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             creatureAsserter.AssertCreature(creature);
@@ -104,7 +104,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         }
 
         [TestCase(CreatureConstants.Titan)]
-        public void BUG_OversizedWeaponHasCorrectAttackDamage(string creatureName)
+        public void BUG_Generate_OversizedWeaponHasCorrectAttackDamage(string creatureName)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             creatureAsserter.AssertCreature(creature);
@@ -165,7 +165,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         [TestCase(CreatureConstants.Orc_Half)]
         [TestCase(CreatureConstants.Goblin)]
         [TestCase(CreatureConstants.Ogre)]
-        public void CanGenerateArmor(string creatureName)
+        public void Generate_Armor(string creatureName)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             creatureAsserter.AssertCreature(creature);
@@ -174,21 +174,21 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         }
 
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.Creatures))]
-        public void CanGenerateCreature(string creatureName)
+        public void Generate_Creature(string creatureName)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             creatureAsserter.AssertCreature(creature);
         }
 
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.Characters))]
-        public void CanGenerateCreatureAsCharacter(string creatureName)
+        public void Generate_CreatureAsCharacter(string creatureName)
         {
             var creature = creatureGenerator.Generate(true, creatureName);
             creatureAsserter.AssertCreatureAsCharacter(creature);
         }
 
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.Templates))]
-        public void CanGenerateBasicTemplate(string template)
+        public void Generate_BasicTemplate(string template)
         {
             var creatureName = CreatureConstants.Human;
             if (template == CreatureConstants.Templates.Lycanthrope_Rat_Afflicted
@@ -215,7 +215,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         }
 
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.Templates))]
-        public void CanGenerateBasicTemplateAsCharacter(string template)
+        public void Generate_BasicTemplateAsCharacter(string template)
         {
             var creatureName = CreatureConstants.Human;
             if (template == CreatureConstants.Templates.Lycanthrope_Rat_Afflicted
@@ -522,7 +522,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         [TestCase(false, CreatureConstants.Wolverine_Dire, CreatureConstants.Templates.FiendishCreature)]
         [TestCase(false, CreatureConstants.Wyvern, CreatureConstants.Templates.Zombie)]
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.ProblematicCreaturesTestCases))]
-        public void CanGenerateTemplate(bool asCharacter, string creatureName, params string[] templates)
+        public void Generate_CanGenerateTemplate(bool asCharacter, string creatureName, params string[] templates)
         {
             var creature = creatureGenerator.Generate(asCharacter, creatureName, null, templates);
             Assert.That(creature.Name, Is.EqualTo(creatureName));
@@ -534,7 +534,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         [TestCase(CreatureConstants.Destrachan)]
         [TestCase(CreatureConstants.Grimlock)]
         [TestCase(CreatureConstants.Yrthak)]
-        public void BUG_DoesNotHaveSight(string creatureName)
+        public void BUG_Generate_DoesNotHaveSight(string creatureName)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             creatureAsserter.AssertCreature(creature);
@@ -557,7 +557,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         [TestCase(CreatureConstants.Elf_High)]
         [TestCase(CreatureConstants.Elf_Wild)]
         [TestCase(CreatureConstants.Elf_Wood)]
-        public void BUG_ElfCanUseShield(string elfName)
+        public void BUG_Generate_ElfCanUseShield(string elfName)
         {
             var elf = creatureGenerator.Generate(false, elfName);
             creatureAsserter.AssertCreature(elf);
@@ -569,7 +569,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         }
 
         [Test]
-        public void BUG_HalfOrcIsNotSensitiveToLight()
+        public void BUG_Generate_HalfOrcIsNotSensitiveToLight()
         {
             var halfOrc = creatureGenerator.Generate(false, CreatureConstants.Orc_Half);
             creatureAsserter.AssertCreature(halfOrc);
@@ -581,7 +581,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         }
 
         [Test]
-        public void BUG_NightcrawlerHasConcentration()
+        public void BUG_Generate_NightcrawlerHasConcentration()
         {
             var nightcrawler = creatureGenerator.Generate(false, CreatureConstants.Nightcrawler);
             creatureAsserter.AssertCreature(nightcrawler);
@@ -677,7 +677,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         [Test]
         [Repeat(10)] //INFO: We have to repeat to ensure we get males, since gender is random
-        public void BUG_MaleSpiderEaterDoesNotHaveImplantAbility()
+        public void BUG_Generate_MaleSpiderEaterDoesNotHaveImplantAbility()
         {
             var spiderEater = creatureGenerator.Generate(false, CreatureConstants.SpiderEater);
             creatureAsserter.AssertCreature(spiderEater);
@@ -699,7 +699,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         [Test]
         [Repeat(10)] //INFO: We have to repeat to ensure we get males, since gender is random
-        public void GenderSpecificAppearancesAreGenerated()
+        public void Generate_GenderSpecificAppearancesAreGenerated()
         {
             var bison = creatureGenerator.Generate(false, CreatureConstants.Bison);
             creatureAsserter.AssertCreature(bison);
@@ -730,7 +730,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         [TestCase(CreatureConstants.YuanTi_Halfblood_SnakeTail, true, true)]
         [TestCase(CreatureConstants.YuanTi_Halfblood_SnakeTailAndHumanLegs, true, true)]
         [TestCase(CreatureConstants.YuanTi_Abomination, true, true)]
-        public void SnakeHasLength(string creatureName, bool hasHeight, bool hasLength)
+        public void Generate_SnakeHasLength(string creatureName, bool hasHeight, bool hasLength)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             creatureAsserter.AssertCreature(creature);
@@ -755,7 +755,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         //INFO: Too many problematic test cases for Repeat to be time-efficient
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.ProblematicCreaturesTestCases))]
-        public void BUG_GenerateProblematicCreature(bool asCharacter, string creatureName, params string[] templates)
+        public void BUG_Generate_ProblematicCreature(bool asCharacter, string creatureName, params string[] templates)
         {
             var randomizer = abilityRandomizerFactory.GetAbilityRandomizer(templates);
             GenerateAndAssertCreature(creatureName, asCharacter, randomizer, templates);
@@ -763,14 +763,14 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         //INFO: Too many problematic test cases for Repeat to be time-efficient
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.ProblematicCreaturesTestCases))]
-        public void BUG_GenerateProblematicCreature_DefaultAbilities(bool asCharacter, string creatureName, params string[] templates)
+        public void BUG_Generate_ProblematicCreature_DefaultAbilities(bool asCharacter, string creatureName, params string[] templates)
         {
             GenerateAndAssertCreature(creatureName, asCharacter, null, templates);
         }
 
         //INFO: Too many problematic test cases for Repeat to be time-efficient
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.ProblematicCreaturesTestCases))]
-        public void BUG_GenerateProblematicCreature_ProblematicAbilities(bool asCharacter, string creatureName, params string[] templates)
+        public void BUG_Generate_ProblematicCreature_ProblematicAbilities(bool asCharacter, string creatureName, params string[] templates)
         {
             var randomizer = abilityRandomizerFactory.GetAbilityRandomizer(templates, [AbilityConstants.RandomizerRolls.Poor, AbilityConstants.RandomizerRolls.Wild]);
             GenerateAndAssertCreature(creatureName, asCharacter, randomizer, templates);
@@ -797,7 +797,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         //INFO: Too many problematic test cases for Repeat to be time-efficient
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.ProblematicFiltersTestCases))]
-        public void BUG_GenerateCreatureWithProblematicFilters(string type, bool asCharacter, string template, string challengeRating, string alignment)
+        public void BUG_GenerateRandom_WithProblematicFilters(string type, bool asCharacter, string template, string challengeRating, string alignment)
         {
             var randomizer = abilityRandomizerFactory.GetAbilityRandomizer([template]);
             GenerateAndAssertRandomCreature(asCharacter, type, challengeRating, alignment, randomizer, template);
@@ -805,14 +805,14 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         //INFO: Too many problematic test cases for Repeat to be time-efficient
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.ProblematicFiltersTestCases))]
-        public void BUG_GenerateCreatureWithProblematicFilters_DefaultAbilities(string type, bool asCharacter, string template, string challengeRating, string alignment)
+        public void BUG_GenerateRandom_WithProblematicFilters_DefaultAbilities(string type, bool asCharacter, string template, string challengeRating, string alignment)
         {
             GenerateAndAssertRandomCreature(asCharacter, type, challengeRating, alignment, null, template);
         }
 
         //INFO: Too many problematic test cases for Repeat to be time-efficient
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.ProblematicFiltersTestCases))]
-        public void BUG_GenerateCreatureWithProblematicFilters_ProblematicAbilities(string type, bool asCharacter, string template, string challengeRating, string alignment)
+        public void BUG_GenerateRandom_WithProblematicFilters_ProblematicAbilities(string type, bool asCharacter, string template, string challengeRating, string alignment)
         {
             var randomizer = abilityRandomizerFactory.GetAbilityRandomizer([template], [AbilityConstants.RandomizerRolls.Poor, AbilityConstants.RandomizerRolls.Wild]);
             GenerateAndAssertRandomCreature(asCharacter, type, challengeRating, alignment, randomizer, template);
@@ -820,7 +820,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         [Test]
         [Repeat(100)]
-        public void BUG_GenerateCreatureWithProblematicFilters_HalfDragonCelestial()
+        public void BUG_GenerateRandom_WithProblematicFilters_HalfDragonCelestial()
         {
             var templates = new[] { CreatureConstants.Templates.HalfDragon_Gold, CreatureConstants.Templates.CelestialCreature };
             var randomizer = abilityRandomizerFactory.GetAbilityRandomizer(templates);
@@ -829,7 +829,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         [Test]
         [Repeat(100)]
-        public void BUG_GenerateCreatureWithProblematicFilters_DriderHalfDragonCelestial()
+        public void BUG_Generate_WithProblematicFilters_DriderHalfDragonCelestial()
         {
             var templates = new[] { CreatureConstants.Templates.HalfDragon_Gold, CreatureConstants.Templates.CelestialCreature };
             var creature = creatureGenerator.Generate(false, CreatureConstants.Drider, null, templates);
@@ -887,7 +887,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         }
 
         [Test]
-        public void AdvancedCreatureHappens()
+        public void Generate_AdvancedCreatureHappens()
         {
             var iterations = 100;
             var advancedHappened = false;
@@ -904,7 +904,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
 
         [TestCase(CreatureConstants.Human, 0)]
         [TestCase(CreatureConstants.Lizardfolk, 2)]
-        public void BUG_CreatureAsCharacterHasCorrectHitDice(string creatureName, double hitDiceQuantity)
+        public void BUG_Generate_CreatureAsCharacterHasCorrectHitDice(string creatureName, double hitDiceQuantity)
         {
             var creature = creatureGenerator.Generate(true, creatureName);
             creatureAsserter.AssertCreatureAsCharacter(creature);
@@ -912,14 +912,14 @@ namespace DnDGen.CreatureGen.Tests.Integration.Generators
         }
 
         [Test]
-        public void DEBUG_GenerateBetaCreature()
+        public void DEBUG_Generate_GenerateBetaCreature()
         {
             var creature = creatureGenerator.Generate(false, CreatureConstants.Lizardfolk);
             Assert.That(creature, Is.Not.Null);
         }
 
         [TestCaseSource(typeof(CreatureTestData), nameof(CreatureTestData.Creatures))]
-        public void BUG_CanDeserializeCreature(string creatureName)
+        public void BUG_Generate_CanDeserializeCreature(string creatureName)
         {
             var creature = creatureGenerator.Generate(false, creatureName);
             var serialized = JsonConvert.SerializeObject(creature);

--- a/DnDGen.CreatureGen.Tests.Integration/TestData/CreatureTestData.cs
+++ b/DnDGen.CreatureGen.Tests.Integration/TestData/CreatureTestData.cs
@@ -177,6 +177,6 @@ namespace DnDGen.CreatureGen.Tests.Integration.TestData
         ];
 
         public static IEnumerable ProblematicFiltersTestCases => ProblematicFilters
-            .Select(pf => new TestCaseData(pf.Filters.Type, pf.AsCharacter, pf.Filters.Templates.FirstOrDefault(), pf.Filters.ChallengeRating, pf.Filters.Alignment));
+            .Select(pf => new TestCaseData(pf.Filters.Type, pf.AsCharacter, pf.Filters.Templates.SingleOrDefault(), pf.Filters.ChallengeRating, pf.Filters.Alignment));
     }
 }

--- a/DnDGen.CreatureGen.Tests.Integration/Verifiers/CreatureVerifierTests.cs
+++ b/DnDGen.CreatureGen.Tests.Integration/Verifiers/CreatureVerifierTests.cs
@@ -234,6 +234,7 @@ namespace DnDGen.CreatureGen.Tests.Integration.Verifiers
         [TestCase(true, false, CreatureConstants.Dragon_Red_GreatWyrm)]
         [TestCase(true, false, CreatureConstants.Dragon_Red_GreatWyrm, CreatureConstants.Templates.None)]
         [TestCase(false, false, CreatureConstants.Dragon_Red_GreatWyrm, CreatureConstants.Templates.Skeleton)]
+        [TestCase(true, false, CreatureConstants.Drider, CreatureConstants.Templates.HalfDragon_Gold, CreatureConstants.Templates.CelestialCreature)]
         [TestCase(true, false, CreatureConstants.Eagle, CreatureConstants.Templates.CelestialCreature)]
         [TestCase(true, false, CreatureConstants.Eagle)]
         [TestCase(true, false, CreatureConstants.Eagle, CreatureConstants.Templates.None)]

--- a/DnDGen.CreatureGen.Tests.Unit/Generators/Alignments/AlignmentGeneratorTests.cs
+++ b/DnDGen.CreatureGen.Tests.Unit/Generators/Alignments/AlignmentGeneratorTests.cs
@@ -1,7 +1,5 @@
-﻿using DnDGen.CreatureGen.Alignments;
-using DnDGen.CreatureGen.Creatures;
+﻿using DnDGen.CreatureGen.Creatures;
 using DnDGen.CreatureGen.Generators.Alignments;
-using DnDGen.CreatureGen.Generators.Creatures;
 using DnDGen.CreatureGen.Tables;
 using DnDGen.CreatureGen.Templates;
 using DnDGen.CreatureGen.Tests.Unit.TestCaseSources;
@@ -89,13 +87,40 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
                 .Returns(["lawfulness goodness", "wrong alignment"]);
 
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(["template alignment", "lawfulness goodness"]);
+            var mockMyTemplateApplicator = new Mock<TemplateApplicator>();
+            var mockMyOtherTemplateApplicator = new Mock<TemplateApplicator>();
 
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment"]);
+            mockFactory.Setup(f => f.Build<TemplateApplicator>("my template")).Returns(mockMyTemplateApplicator.Object);
+            mockFactory.Setup(f => f.Build<TemplateApplicator>("my other template")).Returns(mockMyOtherTemplateApplicator.Object);
+
+            var prototypes1 = new[]
+            {
+                new CreaturePrototype
+                {
+                    Name = "creature name",
+                    Alignments =
+                    [
+                        new("template alignment"),
+                        new("lawfulness goodness"),
+                    ]
+                },
+            };
+            var prototypes2 = new[]
+            {
+                new CreaturePrototype
+                {
+                    Name = "creature name",
+                    Alignments =
+                    [
+                        new("lawfulness goodness"),
+                        new("other-template alignment"),
+                        new("other-wrong alignment"),
+                    ]
+                },
+            };
+
+            mockMyTemplateApplicator.Setup(a => a.GetCompatiblePrototypes(It.Is<IEnumerable<string>>(n => n.IsEquivalentTo(new[] { "creature name" })), false, null)).Returns(prototypes1);
+            mockMyOtherTemplateApplicator.Setup(a => a.GetCompatiblePrototypes(prototypes1, false, null)).Returns(prototypes2);
 
             var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
@@ -154,13 +179,43 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
 
             randomIndex = 1;
 
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
+            var mockMyTemplateApplicator = new Mock<TemplateApplicator>();
+            var mockMyOtherTemplateApplicator = new Mock<TemplateApplicator>();
 
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness"]);
+            mockFactory.Setup(f => f.Build<TemplateApplicator>("my template")).Returns(mockMyTemplateApplicator.Object);
+            mockFactory.Setup(f => f.Build<TemplateApplicator>("my other template")).Returns(mockMyOtherTemplateApplicator.Object);
+
+            var prototypes1 = new[]
+            {
+                new CreaturePrototype
+                {
+                    Name = "creature name",
+                    Alignments =
+                    [
+                        new("template alignment"),
+                        new("lawfulness goodness"),
+                        new("other alignment"),
+                    ]
+                },
+            };
+            var prototypes2 = new[]
+            {
+                new CreaturePrototype
+                {
+                    Name = "creature name",
+                    Alignments =
+                    [
+                        new("lawfulness goodness"),
+                        new("other alignment"),
+                        new("other-template alignment"),
+                        new("other-wrong alignment"),
+                        new("chaotic evilness"),
+                    ]
+                },
+            };
+
+            mockMyTemplateApplicator.Setup(a => a.GetCompatiblePrototypes(It.Is<IEnumerable<string>>(n => n.IsEquivalentTo(new[] { "creature name" })), false, null)).Returns(prototypes1);
+            mockMyOtherTemplateApplicator.Setup(a => a.GetCompatiblePrototypes(prototypes1, false, null)).Returns(prototypes2);
 
             var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
             Assert.That(alignment.Full, Is.EqualTo("other alignment"));
@@ -208,30 +263,10 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         }
 
         [Test]
+        [Ignore("We explicitly do not honor weighting when multiple templates are applied")]
         public void Generate_RandomWeightedAlignment_WithMultipleTemplates()
         {
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(
-                [
-                    "lawfulness goodness",
-                    "wrong alignment",
-                    "lawfulness goodness",
-                    "other alignment"
-                ]);
-
-            randomIndex = 1;
-
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
-
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness"]);
-
-            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
-            Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
+            Assert.Fail("this is not a valid usecase");
         }
 
         [Test]
@@ -297,9 +332,9 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
 
             var mockApplicator1 = new Mock<TemplateApplicator>();
             var mockApplicator2 = new Mock<TemplateApplicator>();
-            var prototypes1 = new[] 
-            { 
-                new CreaturePrototype 
+            var prototypes1 = new[]
+            {
+                new CreaturePrototype
                 {
                     Name = "protoype 1",
                     Alignments =
@@ -310,11 +345,11 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
                         new("wrong lawfulness goodness"),
                         new("other alignment"),
                     ]
-                } 
+                }
             };
             var prototypes2 = new[]
-            { 
-                new CreaturePrototype 
+            {
+                new CreaturePrototype
                 {
                     Name = "protoype 2",
                     Alignments =
@@ -398,37 +433,10 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         }
 
         [Test]
+        [Ignore("We explicitly do not honor weighting when multiple templates are applied")]
         public void Generate_RandomWeightedAlignmentFromMultipleGroups_WithMultipleTemplates()
         {
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(
-                [
-                    "lawfulness goodness",
-                    "wrong alignment",
-                    "lawfulness goodness",
-                    "wrong alignment",
-                    "other alignment",
-                    "wrong alignment",
-                    "wrong lawfulness goodness",
-                    "wrong alignment",
-                    "other alignment",
-                    "wrong alignment",
-                    "other alignment",
-                ]);
-
-            randomIndex = 4;
-
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
-
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness"]);
-
-            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
-            Assert.That(alignment.Full, Is.EqualTo("other alignment"));
+            Assert.Fail("this is not a valid usecase");
         }
     }
 }

--- a/DnDGen.CreatureGen.Tests.Unit/Generators/Alignments/AlignmentGeneratorTests.cs
+++ b/DnDGen.CreatureGen.Tests.Unit/Generators/Alignments/AlignmentGeneratorTests.cs
@@ -1,5 +1,11 @@
-﻿using DnDGen.CreatureGen.Generators.Alignments;
+﻿using DnDGen.CreatureGen.Alignments;
+using DnDGen.CreatureGen.Creatures;
+using DnDGen.CreatureGen.Generators.Alignments;
+using DnDGen.CreatureGen.Generators.Creatures;
 using DnDGen.CreatureGen.Tables;
+using DnDGen.CreatureGen.Templates;
+using DnDGen.CreatureGen.Tests.Unit.TestCaseSources;
+using DnDGen.Infrastructure.Factories;
 using DnDGen.Infrastructure.Selectors.Collections;
 using Moq;
 using NUnit.Framework;
@@ -13,13 +19,15 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
     {
         private IAlignmentGenerator alignmentGenerator;
         private Mock<ICollectionSelector> mockCollectionSelector;
+        private Mock<JustInTimeFactory> mockFactory;
         private int randomIndex;
 
         [SetUp]
         public void Setup()
         {
             mockCollectionSelector = new Mock<ICollectionSelector>();
-            alignmentGenerator = new AlignmentGenerator(mockCollectionSelector.Object);
+            mockFactory = new Mock<JustInTimeFactory>();
+            alignmentGenerator = new AlignmentGenerator(mockCollectionSelector.Object, mockFactory.Object);
 
             randomIndex = 0;
             mockCollectionSelector
@@ -37,14 +45,14 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         [Test]
         public void Generate_PresetAlignment_WithTemplate()
         {
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template" }, "lawfulness goodness");
+            var alignment = alignmentGenerator.Generate("creature name", ["my template"], "lawfulness goodness");
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
         }
 
         [Test]
         public void Generate_PresetAlignment_WithMultipleTemplates()
         {
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template", "my other template" }, "lawfulness goodness");
+            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], "lawfulness goodness");
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
         }
 
@@ -53,7 +61,7 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[] { "lawfulness goodness" });
+                .Returns(["lawfulness goodness"]);
 
             var alignment = alignmentGenerator.Generate("creature name", null, null);
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
@@ -64,13 +72,13 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[] { "other wrong alignment", "lawfulness goodness", "wrong alignment" });
+                .Returns(["other wrong alignment", "lawfulness goodness", "wrong alignment"]);
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness" });
+                .Returns(["template alignment", "lawfulness goodness"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template"], null);
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
         }
 
@@ -79,17 +87,17 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[] { "lawfulness goodness", "wrong alignment" });
+                .Returns(["lawfulness goodness", "wrong alignment"]);
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness" });
+                .Returns(["template alignment", "lawfulness goodness"]);
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "other template alignment", "lawfulness goodness", "other wrong alignment" });
+                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template", "my other template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
         }
 
@@ -98,11 +106,11 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "other alignment"
-                });
+                ]);
 
             randomIndex = 1;
 
@@ -115,20 +123,20 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 1;
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other alignment" });
+                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template"], null);
             Assert.That(alignment.Full, Is.EqualTo("other alignment"));
         }
 
@@ -137,24 +145,24 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 1;
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other alignment" });
+                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness" });
+                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template", "my other template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
             Assert.That(alignment.Full, Is.EqualTo("other alignment"));
         }
 
@@ -163,12 +171,12 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "lawfulness goodness",
                     "other alignment"
-                });
+                ]);
 
             randomIndex = 1;
 
@@ -181,21 +189,21 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "lawfulness goodness",
                     "other alignment"
-                });
+                ]);
 
             randomIndex = 1;
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other alignment" });
+                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template"], null);
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
         }
 
@@ -204,25 +212,25 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "lawfulness goodness",
                     "other alignment"
-                });
+                ]);
 
             randomIndex = 1;
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other alignment" });
+                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness" });
+                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template", "my other template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
             Assert.That(alignment.Full, Is.EqualTo("lawfulness goodness"));
         }
 
@@ -231,13 +239,13 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "other alignment",
                     "wrong lawfulness goodness",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 3;
 
@@ -250,23 +258,23 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "other alignment",
                     "wrong lawfulness goodness",
                     "wrong alignment",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 3;
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other wrong alignment", "wrong lawfulness goodness", "other alignment" });
+                .Returns(["template alignment", "lawfulness goodness", "other wrong alignment", "wrong lawfulness goodness", "other alignment"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template"], null);
             Assert.That(alignment.Full, Is.EqualTo("other alignment"));
         }
 
@@ -275,27 +283,66 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "other alignment",
                     "wrong lawfulness goodness",
                     "wrong alignment",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 2;
 
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other wrong alignment", "wrong lawfulness goodness", "other alignment" });
+            var mockApplicator1 = new Mock<TemplateApplicator>();
+            var mockApplicator2 = new Mock<TemplateApplicator>();
+            var prototypes1 = new[] 
+            { 
+                new CreaturePrototype 
+                {
+                    Name = "protoype 1",
+                    Alignments =
+                    [
+                        new("template alignment"),
+                        new("lawfulness goodness"),
+                        new("other wrong alignment"),
+                        new("wrong lawfulness goodness"),
+                        new("other alignment"),
+                    ]
+                } 
+            };
+            var prototypes2 = new[]
+            { 
+                new CreaturePrototype 
+                {
+                    Name = "protoype 2",
+                    Alignments =
+                    [
+                        new("template2 alignment"),
+                        new("lawfulness goodness"),
+                        new("other alignment"),
+                        new("wrong2 alignment"),
+                        new("chaotic evilness"),
+                    ]
+                }
+            };
 
-            mockCollectionSelector
-                .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness" });
+            mockApplicator1
+                .Setup(a => a.GetCompatiblePrototypes(It.Is<IEnumerable<string>>(cc => cc.IsEquivalentTo(new[] { "creature name" })), false, null))
+                .Returns(prototypes1);
+            mockApplicator2
+                .Setup(a => a.GetCompatiblePrototypes(prototypes1, false, null))
+                .Returns(prototypes2);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template", "my other template" }, null);
+            mockFactory
+                .Setup(f => f.Build<TemplateApplicator>("my template"))
+                .Returns(mockApplicator1.Object);
+            mockFactory
+                .Setup(f => f.Build<TemplateApplicator>("my other template"))
+                .Returns(mockApplicator2.Object);
+
+            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
             Assert.That(alignment.Full, Is.EqualTo("other alignment"));
         }
 
@@ -304,15 +351,15 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "lawfulness goodness",
                     "other alignment",
                     "wrong lawfulness goodness",
                     "other alignment",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 4;
 
@@ -325,8 +372,8 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "lawfulness goodness",
@@ -338,15 +385,15 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
                     "other alignment",
                     "wrong alignment",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 4;
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other alignment" });
+                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template"], null);
             Assert.That(alignment.Full, Is.EqualTo("other alignment"));
         }
 
@@ -355,8 +402,8 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
         {
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "creature name"))
-                .Returns(new[]
-                {
+                .Returns(
+                [
                     "lawfulness goodness",
                     "wrong alignment",
                     "lawfulness goodness",
@@ -368,19 +415,19 @@ namespace DnDGen.CreatureGen.Tests.Unit.Generators.Alignments
                     "other alignment",
                     "wrong alignment",
                     "other alignment",
-                });
+                ]);
 
             randomIndex = 4;
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "template alignment", "lawfulness goodness", "other alignment" });
+                .Returns(["template alignment", "lawfulness goodness", "other alignment"]);
 
             mockCollectionSelector
                 .Setup(s => s.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, "my other template" + GroupConstants.AllowedInput))
-                .Returns(new[] { "other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness" });
+                .Returns(["other template alignment", "lawfulness goodness", "other wrong alignment", "other alignment", "chaotic evilness"]);
 
-            var alignment = alignmentGenerator.Generate("creature name", new[] { "my template", "my other template" }, null);
+            var alignment = alignmentGenerator.Generate("creature name", ["my template", "my other template"], null);
             Assert.That(alignment.Full, Is.EqualTo("other alignment"));
         }
     }

--- a/DnDGen.CreatureGen/DnDGen.CreatureGen.csproj
+++ b/DnDGen.CreatureGen/DnDGen.CreatureGen.csproj
@@ -5,7 +5,7 @@
     <Authors>Karl M. Speer</Authors>
     <Company>DnDGen</Company>
     <Product>CreatureGen</Product>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
     <Description>This generates creatures for the Dungeons and Dragons 3.5 system.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/DnDGen/CreatureGen</PackageProjectUrl>
@@ -13,7 +13,7 @@
     <PackageIconUrl />
     <RepositoryUrl>https://github.com/DnDGen/CreatureGen</RepositoryUrl>
     <PackageTags>creature generator dice dungeons dragons d20 dnd 3.5 gen</PackageTags>
-    <PackageReleaseNotes>Fix HitPoints serialization when no Constituation</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix alignment generation validity when generating with multiple templates</PackageReleaseNotes>
 	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/DnDGen.CreatureGen/Generators/Alignments/AlignmentGenerator.cs
+++ b/DnDGen.CreatureGen/Generators/Alignments/AlignmentGenerator.cs
@@ -1,34 +1,55 @@
 ﻿using DnDGen.CreatureGen.Alignments;
 using DnDGen.CreatureGen.Tables;
+using DnDGen.CreatureGen.Templates;
+using DnDGen.CreatureGen.Verifiers.Exceptions;
+using DnDGen.Infrastructure.Factories;
 using DnDGen.Infrastructure.Selectors.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace DnDGen.CreatureGen.Generators.Alignments
 {
-    internal class AlignmentGenerator : IAlignmentGenerator
+    internal class AlignmentGenerator(ICollectionSelector collectionSelector, JustInTimeFactory factory) : IAlignmentGenerator
     {
-        private readonly ICollectionSelector collectionSelector;
-
-        public AlignmentGenerator(ICollectionSelector collectionSelector)
-        {
-            this.collectionSelector = collectionSelector;
-        }
-
         public Alignment Generate(string creatureName, IEnumerable<string> templates, string presetAlignment)
         {
             if (!string.IsNullOrEmpty(presetAlignment))
                 return new Alignment(presetAlignment);
 
             var weightedAlignments = collectionSelector.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, creatureName);
-            templates ??= [];
+            var templatesArray = templates?.ToArray() ?? [];
 
-            foreach (var template in templates)
+            if (templatesArray.Length == 1)
             {
-                var templateAlignments = collectionSelector.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, template + GroupConstants.AllowedInput);
+                var templateAlignments = collectionSelector.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, templatesArray[0] + GroupConstants.AllowedInput);
+
                 //INFO: Doing this instead of intersect in order to preserve duplicates
                 weightedAlignments = weightedAlignments.Where(templateAlignments.Contains);
             }
+            else if (templatesArray.Length > 1)
+            {
+                var applicator = factory.Build<TemplateApplicator>(templatesArray[0]);
+                var prototypes = applicator.GetCompatiblePrototypes([creatureName], false);
+
+                for (var i = 1; i < templatesArray.Length; i++)
+                {
+                    applicator = factory.Build<TemplateApplicator>(templatesArray[i]);
+
+                    //INFO: The only filter we would care bout would be a prest alignment, which we already handle earlier
+                    //So we do not need to pass filters to the applicators
+                    prototypes = applicator.GetCompatiblePrototypes(prototypes, false);
+                }
+
+                //INFO: At thi point, after multiple templates, we are choosing to ignore weighting
+                weightedAlignments = prototypes.SelectMany(p => p.Alignments).Select(a => a.Full);
+            }
+
+            if (!weightedAlignments.Any())
+                throw new InvalidCreatureException(
+                    $"Creature {creatureName} has no valid alignments for templates [{string.Join(", ", templates)}]",
+                    false,
+                    creatureName,
+                    null);
 
             var randomAlignment = collectionSelector.SelectRandomFrom(weightedAlignments);
 

--- a/DnDGen.CreatureGen/Generators/Alignments/AlignmentGenerator.cs
+++ b/DnDGen.CreatureGen/Generators/Alignments/AlignmentGenerator.cs
@@ -16,34 +16,7 @@ namespace DnDGen.CreatureGen.Generators.Alignments
             if (!string.IsNullOrEmpty(presetAlignment))
                 return new Alignment(presetAlignment);
 
-            var weightedAlignments = collectionSelector.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, creatureName);
-            var templatesArray = templates?.ToArray() ?? [];
-
-            if (templatesArray.Length == 1)
-            {
-                var templateAlignments = collectionSelector.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, templatesArray[0] + GroupConstants.AllowedInput);
-
-                //INFO: Doing this instead of intersect in order to preserve duplicates
-                weightedAlignments = weightedAlignments.Where(templateAlignments.Contains);
-            }
-            else if (templatesArray.Length > 1)
-            {
-                var applicator = factory.Build<TemplateApplicator>(templatesArray[0]);
-                var prototypes = applicator.GetCompatiblePrototypes([creatureName], false);
-
-                for (var i = 1; i < templatesArray.Length; i++)
-                {
-                    applicator = factory.Build<TemplateApplicator>(templatesArray[i]);
-
-                    //INFO: The only filter we would care bout would be a prest alignment, which we already handle earlier
-                    //So we do not need to pass filters to the applicators
-                    prototypes = applicator.GetCompatiblePrototypes(prototypes, false);
-                }
-
-                //INFO: At thi point, after multiple templates, we are choosing to ignore weighting
-                weightedAlignments = prototypes.SelectMany(p => p.Alignments).Select(a => a.Full);
-            }
-
+            var weightedAlignments = GetWeightedAlignments(creatureName, templates);
             if (!weightedAlignments.Any())
                 throw new InvalidCreatureException(
                     $"Creature {creatureName} has no valid alignments for templates [{string.Join(", ", templates)}]",
@@ -52,8 +25,43 @@ namespace DnDGen.CreatureGen.Generators.Alignments
                     null);
 
             var randomAlignment = collectionSelector.SelectRandomFrom(weightedAlignments);
-
             return new Alignment(randomAlignment);
+        }
+
+        private IEnumerable<string> GetWeightedAlignments(string creatureName, IEnumerable<string> templates)
+        {
+            var weightedAlignments = collectionSelector.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, creatureName);
+            var templatesArray = templates?.ToArray() ?? [];
+
+            if (templatesArray.Length == 0)
+                return weightedAlignments;
+
+            if (templatesArray.Length == 1)
+            {
+                var templateAlignments = collectionSelector.SelectFrom(Config.Name, TableNameConstants.Collection.AlignmentGroups, templatesArray[0] + GroupConstants.AllowedInput);
+
+                //INFO: Doing this instead of intersect in order to preserve duplicates
+                weightedAlignments = weightedAlignments.Where(templateAlignments.Contains);
+
+                return weightedAlignments;
+            }
+
+            var applicator = factory.Build<TemplateApplicator>(templatesArray[0]);
+            var prototypes = applicator.GetCompatiblePrototypes([creatureName], false);
+
+            for (var i = 1; i < templatesArray.Length; i++)
+            {
+                applicator = factory.Build<TemplateApplicator>(templatesArray[i]);
+
+                //INFO: The only filter we would care about would be a preset alignment, which we already handle earlier
+                //So we do not need to pass filters to the applicators
+                prototypes = applicator.GetCompatiblePrototypes(prototypes, false);
+            }
+
+            //INFO: At this point, after multiple templates, we are choosing to ignore weighting
+            weightedAlignments = prototypes.SelectMany(p => p.Alignments).Select(a => a.Full);
+
+            return weightedAlignments;
         }
     }
 }

--- a/DnDGen.CreatureGen/Verifiers/ICreatureVerifier.cs
+++ b/DnDGen.CreatureGen/Verifiers/ICreatureVerifier.cs
@@ -1,4 +1,5 @@
 ﻿using DnDGen.CreatureGen.Generators.Creatures;
+using System.Collections;
 
 namespace DnDGen.CreatureGen.Verifiers
 {


### PR DESCRIPTION
The alignment generator, when applying multiple templates, was not going through template application correctly, which affects the allowed generated alignments. We can't just check inputs for validity, since the applicators also modify the existing input alignments. The only way to chain them is to go through proper applicator chaining. The alignment generator was updated to do that, with corresponding tests.